### PR TITLE
Jakarta.json support.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,4 +27,4 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-jdk-${{ matrix.java }}-mvn-
       - name: Maven verify
-        run: mvn clean verify -B
+        run: mvn clean verify -B -Pqulice

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build and test](https://github.com/g4s8/matchers-json/actions/workflows/maven.yml/badge.svg)](https://github.com/g4s8/matchers-json/actions/workflows/maven.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/wtf.g4s8/matchers-json.svg)](https://maven-badges.herokuapp.com/maven-central/wtf.g4s8/matchers-json)
 
-[Hamcrest matchers](http://hamcrest.org/JavaHamcrest/) for `javax.json` objects and arrays, and raw JSON strings.
+[Hamcrest matchers](http://hamcrest.org/JavaHamcrest/) for `jakarta.json` objects and arrays, and raw JSON strings.
 
 [![PDD status](http://www.0pdd.com/svg?name=g4s8/matchers-json)](http://www.0pdd.com/p?name=g4s8/matchers-json)
 [![License](https://img.shields.io/github/license/g4s8/matchers-json.svg?style=flat-square)](https://github.com/g4s8/matchers-json/blob/master/LICENSE)
@@ -21,7 +21,7 @@ Add dependency to your `pom.xml`:
 </dependency>
 ```
 you can find latest version on Bintray badge above.
-Also, this library depends on `javax.json:javax.json-api` library.
+Also, this library depends on `jakarta.json:jakarta.json-api` library.
 
 ## Example
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,9 +122,9 @@
   </build>
   <dependencies>
     <dependency>
-      <groupId>javax.json</groupId>
-      <artifactId>javax.json-api</artifactId>
-      <version>1.1</version>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
+      <version>2.1.3</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -133,9 +133,9 @@
       <version>2.1</version>
     </dependency>
     <dependency>
-      <groupId>org.glassfish</groupId>
-      <artifactId>javax.json</artifactId>
-      <version>1.1</version>
+      <groupId>org.eclipse.parsson</groupId>
+      <artifactId>parsson</artifactId>
+      <version>1.1.7</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/wtf/g4s8/hamcrest/json/JsonContains.java
+++ b/src/main/java/wtf/g4s8/hamcrest/json/JsonContains.java
@@ -29,9 +29,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
 import javax.json.JsonArray;
 import javax.json.JsonValue;
 import org.hamcrest.Description;
@@ -74,21 +72,36 @@ public final class JsonContains extends TypeSafeMatcher<JsonArray> {
         this.matchers = Collections.unmodifiableList(matchers);
     }
 
+    /**
+     * Match provided numbers.
+     *
+     * @param nums Numbers
+     */
     public JsonContains(final Number... nums) {
         this(
             Stream.of(nums).map(JsonValueIs::new).collect(Collectors.toList())
         );
     }
 
-    public JsonContains(final String... ints) {
+    /**
+     * Match provided strings.
+     *
+     * @param strs Strings
+     */
+    public JsonContains(final String... strs) {
         this(
-            Stream.of(ints).map(JsonValueIs::new).collect(Collectors.toList())
+            Stream.of(strs).map(JsonValueIs::new).collect(Collectors.toList())
         );
     }
 
-    public JsonContains(final Boolean... ints) {
+    /**
+     * Match provided booleans.
+     *
+     * @param bools Booleans
+     */
+    public JsonContains(final Boolean... bools) {
         this(
-            Stream.of(ints).map(JsonValueIs::new).collect(Collectors.toList())
+            Stream.of(bools).map(JsonValueIs::new).collect(Collectors.toList())
         );
     }
 

--- a/src/main/java/wtf/g4s8/hamcrest/json/JsonContains.java
+++ b/src/main/java/wtf/g4s8/hamcrest/json/JsonContains.java
@@ -25,13 +25,13 @@
 
 package wtf.g4s8.hamcrest.json;
 
+import jakarta.json.JsonArray;
+import jakarta.json.JsonValue;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.json.JsonArray;
-import javax.json.JsonValue;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;

--- a/src/main/java/wtf/g4s8/hamcrest/json/JsonHas.java
+++ b/src/main/java/wtf/g4s8/hamcrest/json/JsonHas.java
@@ -24,8 +24,8 @@
  */
 package wtf.g4s8.hamcrest.json;
 
-import javax.json.JsonObject;
-import javax.json.JsonValue;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;

--- a/src/main/java/wtf/g4s8/hamcrest/json/JsonValueIs.java
+++ b/src/main/java/wtf/g4s8/hamcrest/json/JsonValueIs.java
@@ -24,8 +24,8 @@
  */
 package wtf.g4s8.hamcrest.json;
 
+import jakarta.json.JsonValue;
 import java.util.Locale;
-import javax.json.JsonValue;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;

--- a/src/main/java/wtf/g4s8/hamcrest/json/StringIsJson.java
+++ b/src/main/java/wtf/g4s8/hamcrest/json/StringIsJson.java
@@ -60,8 +60,10 @@ public abstract class StringIsJson extends TypeSafeMatcher<String> {
      * @param matcher Json matcher
      * @param parsing Json parsing
      */
-    private StringIsJson(final Matcher<? extends JsonValue> matcher,
-                         final Function<JsonReader, JsonValue> parsing) {
+    private StringIsJson(
+        final Matcher<? extends JsonValue> matcher,
+        final Function<JsonReader, JsonValue> parsing
+    ) {
         super();
         this.matcher = matcher;
         this.parsing = parsing;
@@ -74,8 +76,10 @@ public abstract class StringIsJson extends TypeSafeMatcher<String> {
     }
 
     @Override
-    public void describeMismatchSafely(final String item,
-                                       final Description description) {
+    public void describeMismatchSafely(
+        final String item,
+        final Description description
+    ) {
         description.appendText("string: '")
             .appendValue(item)
             .appendText("' ");

--- a/src/main/java/wtf/g4s8/hamcrest/json/StringIsJson.java
+++ b/src/main/java/wtf/g4s8/hamcrest/json/StringIsJson.java
@@ -24,14 +24,14 @@
  */
 package wtf.g4s8.hamcrest.json;
 
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonParsingException;
 import java.io.StringReader;
 import java.util.function.Function;
-import javax.json.Json;
-import javax.json.JsonArray;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
-import javax.json.JsonValue;
-import javax.json.stream.JsonParsingException;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -61,7 +61,7 @@ public abstract class StringIsJson extends TypeSafeMatcher<String> {
      * @param parsing Json parsing
      */
     private StringIsJson(final Matcher<? extends JsonValue> matcher,
-        final Function<JsonReader, JsonValue> parsing) {
+                         final Function<JsonReader, JsonValue> parsing) {
         super();
         this.matcher = matcher;
         this.parsing = parsing;
@@ -75,7 +75,7 @@ public abstract class StringIsJson extends TypeSafeMatcher<String> {
 
     @Override
     public void describeMismatchSafely(final String item,
-        final Description description) {
+                                       final Description description) {
         description.appendText("string: '")
             .appendValue(item)
             .appendText("' ");

--- a/src/main/java/wtf/g4s8/hamcrest/json/package-info.java
+++ b/src/main/java/wtf/g4s8/hamcrest/json/package-info.java
@@ -23,7 +23,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 /**
- * Hamcrest matchers for {@link javax.json.Json} objects.
+ * Hamcrest matchers for {@link jakarta.json.Json} objects.
  *
  * @since 1.0
  */

--- a/src/test/java/wtf/g4s8/hamcrest/json/JsonContainsCase.java
+++ b/src/test/java/wtf/g4s8/hamcrest/json/JsonContainsCase.java
@@ -39,7 +39,9 @@ import wtf.g4s8.oot.TestGroup;
  * @since 0.2
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocParameterOrderCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class JsonContainsCase extends TestGroup.Wrap {
 
     /**
@@ -66,15 +68,18 @@ public final class JsonContainsCase extends TestGroup.Wrap {
                 ),
                 new NestedObjectTest(),
                 new ComplexHierarchyTest(),
-                new SimpleTest<>("Number varargs",
+                new SimpleTest<>(
+                    "Number varargs",
                     Json.createArrayBuilder().add(1).add(2).add(3).build(),
                     new JsonContains(1, 2, 3)
                 ),
-                new SimpleTest<>("String varargs",
+                new SimpleTest<>(
+                    "String varargs",
                     Json.createArrayBuilder().add("qwe").add("asd").add("zxc").build(),
                     new JsonContains("qwe", "asd", "zxc")
                 ),
-                new SimpleTest<>("Boolean varargs",
+                new SimpleTest<>(
+                    "Boolean varargs",
                     Json.createArrayBuilder().add(true).add(false).add(false).build(),
                     new JsonContains(true, false, false)
                 )
@@ -127,8 +132,10 @@ public final class JsonContainsCase extends TestGroup.Wrap {
          * Primary ctor.
          * @checkstyle ParameterNumberCheck (5 lines)
          */
-        private ComplexHierarchyTest(final String kname, final String kvalues,
-            final String kvalue, final String vsecond, final String vfirst) {
+        private ComplexHierarchyTest(
+            final String kname, final String kvalues,
+            final String kvalue, final String vsecond, final String vfirst
+        ) {
             super(
                 new SimpleTest<JsonArray>(
                     "complex hierarchy",
@@ -145,15 +152,15 @@ public final class JsonContainsCase extends TestGroup.Wrap {
                                         )
                                 )
                         ).add(
-                        Json.createObjectBuilder()
-                            .add(kname, vsecond)
-                            .add(
-                                kvalues,
-                                Json.createArrayBuilder()
-                                    .add(Json.createObjectBuilder().add(kvalue, 1))
-                                    .add(Json.createObjectBuilder().add(kvalue, 2))
-                            )
-                    ).build(),
+                            Json.createObjectBuilder()
+                                .add(kname, vsecond)
+                                .add(
+                                    kvalues,
+                                    Json.createArrayBuilder()
+                                        .add(Json.createObjectBuilder().add(kvalue, 1))
+                                        .add(Json.createObjectBuilder().add(kvalue, 2))
+                                )
+                        ).build(),
                     new JsonContains(
                         Matchers.allOf(
                             Arrays.asList(

--- a/src/test/java/wtf/g4s8/hamcrest/json/JsonContainsCase.java
+++ b/src/test/java/wtf/g4s8/hamcrest/json/JsonContainsCase.java
@@ -24,10 +24,10 @@
  */
 package wtf.g4s8.hamcrest.json;
 
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonValue;
 import java.util.Arrays;
-import javax.json.Json;
-import javax.json.JsonArray;
-import javax.json.JsonValue;
 import org.hamcrest.Matchers;
 import wtf.g4s8.oot.SimpleTest;
 import wtf.g4s8.oot.TestCase;

--- a/src/test/java/wtf/g4s8/hamcrest/json/JsonHasCase.java
+++ b/src/test/java/wtf/g4s8/hamcrest/json/JsonHasCase.java
@@ -24,9 +24,9 @@
  */
 package wtf.g4s8.hamcrest.json;
 
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonValue;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 import wtf.g4s8.oot.SimpleTest;
 import wtf.g4s8.oot.TestCase;
 import wtf.g4s8.oot.TestGroup;
@@ -174,4 +174,3 @@ public final class JsonHasCase extends TestGroup.Wrap {
         }
     }
 }
-

--- a/src/test/java/wtf/g4s8/hamcrest/json/JsonValueIsCase.java
+++ b/src/test/java/wtf/g4s8/hamcrest/json/JsonValueIsCase.java
@@ -24,8 +24,8 @@
  */
 package wtf.g4s8.hamcrest.json;
 
-import javax.json.Json;
-import javax.json.JsonValue;
+import jakarta.json.Json;
+import jakarta.json.JsonValue;
 import org.hamcrest.Matchers;
 import wtf.g4s8.oot.SimpleTest;
 import wtf.g4s8.oot.TestGroup;
@@ -46,17 +46,17 @@ public final class JsonValueIsCase extends TestGroup.Wrap {
         super(
             new TestGroup.Of(
                 "json-value-is",
-                new SimpleTest<JsonValue>(
+                new SimpleTest<>(
                     "matches string",
                     Json.createValue(JsonValueIsCase.class.getSimpleName()),
                     new JsonValueIs(JsonValueIsCase.class.getSimpleName())
                 ),
-                new SimpleTest<JsonValue>(
+                new SimpleTest<>(
                     "matches number",
                     Json.createValue(1),
                     new JsonValueIs(1)
                 ),
-                new SimpleTest<JsonValue>(
+                new SimpleTest<>(
                     "matches custom matchers",
                     Json.createValue("Starting with 1 2 3"),
                     new JsonValueIs(

--- a/src/test/java/wtf/g4s8/hamcrest/json/ReadmeExamplesCase.java
+++ b/src/test/java/wtf/g4s8/hamcrest/json/ReadmeExamplesCase.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Kirill
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights * to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
 package wtf.g4s8.hamcrest.json;
 
 import javax.json.Json;
@@ -7,31 +31,57 @@ import wtf.g4s8.oot.TestGroup;
 
 /**
  * Examples from README doc.
+ *
+ * @since 1.5
+ * @checkstyle MethodBodyCommentsCheck (100 lines)
+ * @checkstyle TrailingCommentCheck (100 lines)
+ * @checkstyle MagicNumberCheck (100 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class ReadmeExamplesCase extends TestGroup.Wrap {
-    public ReadmeExamplesCase() {
+
+    /**
+     * Ctor with readme sample test.
+     */
+    ReadmeExamplesCase() {
         super(
             new TestGroup.Of(
                 new SimpleTest<>(
                     "Main example from readme works",
                     // example json object
-                    Json.createObjectBuilder().add(
-                        "response", // with nested object
-                        Json.createObjectBuilder()
-                        .add("result", 42) // with string
-                        .add("constant", true) // with bool
-                        .add("description", "result of 40 + 2")
-                        .add("function", Json.createObjectBuilder() // with nested object
-                            .add("name", "sum")
-                            .add("args", Json.createArrayBuilder().add(40).add(2)))) // with nested array
-                        .build(),
-                    new JsonHas("response", Matchers.allOf(
-                        new JsonHas("constant", true), // match object in any order
-                        new JsonHas("result", 42), // match exact value - same as Matchers.equalTo(42)
-                        new JsonHas("description", new JsonValueIs(Matchers.stringContainsInOrder("result", "40 + 2"))), // match with matcher
-                        new JsonHas("function", Matchers.allOf( // match all fields of nested object
-                            new JsonHas("name", "sum"), // exact match
-                            new JsonHas("args",  new JsonContains(40, 2)))))) // match nested array (ordered matcher)
+                    Json.createObjectBuilder()
+                        .add(
+                            "response", // with nested object
+                            Json.createObjectBuilder()
+                                .add("result", 42) // with string
+                                .add("constant", true) // with bool
+                                .add("description", "result of 40 + 2")
+                                .add(
+                                    "function",
+                                    Json.createObjectBuilder() // with nested object
+                                        .add("name", "sum")
+                                        .add("args", Json.createArrayBuilder().add(40).add(2))
+                                )
+                        ).build(), // with nested array
+                    new JsonHas(
+                        "response",
+                        Matchers.allOf(
+                            new JsonHas("constant", true), // match object in any order
+                            new JsonHas("result", 42),
+                            // match exact value - same as Matchers.equalTo(42)
+                            new JsonHas(
+                                "description",
+                                new JsonValueIs(Matchers.stringContainsInOrder("result", "40 + 2"))
+                            ), // match with matcher
+                            new JsonHas(
+                                "function",
+                                Matchers.allOf(// match all fields of nested object
+                                    new JsonHas("name", "sum"), // exact match
+                                    new JsonHas("args", new JsonContains(40, 2))
+                                )
+                            )
+                        )
+                    ) // match nested array (ordered matcher)
                 )
             )
         );

--- a/src/test/java/wtf/g4s8/hamcrest/json/ReadmeExamplesCase.java
+++ b/src/test/java/wtf/g4s8/hamcrest/json/ReadmeExamplesCase.java
@@ -24,7 +24,7 @@
  */
 package wtf.g4s8.hamcrest.json;
 
-import javax.json.Json;
+import jakarta.json.Json;
 import org.hamcrest.Matchers;
 import wtf.g4s8.oot.SimpleTest;
 import wtf.g4s8.oot.TestGroup;

--- a/src/test/java/wtf/g4s8/hamcrest/json/StringIsJsonCase.java
+++ b/src/test/java/wtf/g4s8/hamcrest/json/StringIsJsonCase.java
@@ -24,8 +24,8 @@
  */
 package wtf.g4s8.hamcrest.json;
 
-import javax.json.JsonArray;
-import javax.json.JsonObject;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
 import org.hamcrest.Matchers;
 import wtf.g4s8.oot.SimpleTest;
 import wtf.g4s8.oot.TestGroup;


### PR DESCRIPTION
1)Fixed qulice checks, I decided to suppress some of them due to fixing them would bloat the code base (tests).
2)Included qulice checks in maven gha.
3)Change namespace from javax.json -> jakarta.json
4)Change org.glassfish:javax.json -> org.eclipse.parsson:parsson

Closes #16
